### PR TITLE
Add docstrings, refactor ingest_mobilize_pipeline

### DIFF
--- a/ingest_mobilize_pipeline.py
+++ b/ingest_mobilize_pipeline.py
@@ -1,53 +1,97 @@
+"""Ingests Event Attendances data from Mobilize API and loads the data into bigquery."""
 import requests
 from google.cloud import bigquery
 import os
+import logging
+import smart_open
+import json
+from datetime import datetime, timezone
 
-
-def download_data() -> json[list[dict]]:
-    base_url = "https://api.mobilize.us/v1/"
+def download_attendances_data() -> json[list[dict]]:
+    """
+    Send a get request to the mobilize API's Attendances endpoint and retrieves all data from attendances endpoint
+    """
+    base_url = "https://api.mobilize.us/v1/"    
     endpoint = "attendances"
     headers = {"Authorization": "Bearer {}".format(os.environ.get("MOBILIZE_API_KEY"))}
 
     response = requests.get(base_url + endpoint, headers=headers)
+
     result = response.json
+
+    if result["error"]:
+        logging.error(f"Failed to retrieve attendances data with error: {result["error"]}")
+    
     return result
 
+def extract_event_data(row: dict) -> dict:
+    """Takes a row of Mobilize API data and returns a dict of specific key:value pairs for that event.
+    
+    Args:
+        row: a dict of events from the Mobilize API json response
+    """
+    event = {
+        key: value
+        for key, value in row["event"].items()
+        if key
+        in (
+            "created_date",
+            "modified_date",
+            "id",
+            "title",
+            "event_type",
+            "summary",
+            "description",
+        )
+    }
+    return event
 
-def save_data(data: list[dict]) -> str:
-    fp = "data/attendances.json"
-    f = open(filepath, "w")
-    import json
 
-    json.dump(data, f, indent=4)
+def save_data_to_gcs(data: list[dict], filepath: str) -> str:
+    """
+    Takes a json of event data, transforms data into rows, and saves to google cloud storage with the given filepath.
 
+    Args:
+        data: a list of attendance objects from the Mobilize attendances API
+        filepath: the filepath to write to in GCS, relative to 'gs://mobilize/{filepath}'
+    """
 
-def load_events(filepath: str):
-    file = open("data/attendances.json", "r")
-    data = file.read()
+    with smart_open.open(f'gs://mobilize/{filepath}', 'wb') as fout:
+        for row in data:
+            try:
+                fout.write(extract_event_data(row))
+            except Exception as e:
+                logging.error(f"Error loading row {row}, with error {e}")
 
-    for row in data:
+def load_events_to_bigquery(filepath: str):
+    """
+    Stream events data from a filepath in google cloud storage into bigquery events table
+    
+    Args:
+        filepath: the filepath to read from in GCS, relative to 'gs://mobilize/{filepath}'
+    """
+    client = bigquery.Client()
+    table = client.get_table("wfp-data-project.mobilize.events")
+
+    # stream from GCS
+    for event in smart_open(f'gs://mobilize/{filepath}'):
         try:
-            client = bigquery.Client()
-            table = client.get_table("wfp-data-project.mobilize.events")
-            event = {
-                key: value
-                for key, value in row["event"].items()
-                if key
-                in (
-                    "created_date",
-                    "modified_date",
-                    "id",
-                    "title",
-                    "event_type",
-                    "summary",
-                    "description",
-                )
-            }
             client.insert_rows(table, [event])
-        except:
-            print("error loading row")
+        except Exception as e:
+            logging.error(f"Error loading row into bigquery. Row: {event}")
 
 
-data = download_data()
-filepath = save_data(data)
-loadevents(filepath)
+timestamp = datetime.now(timezone.utc)
+
+response_json = download_attendances_data()
+data = response_json["data"]
+
+# Only try loading data if the API returned any data.
+if data:
+    filepath = f"attendances/{timestamp}.json"
+
+    data_csv = extract_event_data()
+
+    save_data_to_gcs(data_csv, filepath)
+    load_events_to_bigquery(filepath)
+


### PR DESCRIPTION
This file is largely pseudocode and doesn't work. Theoretically, this script pulls all attendance data from the fake `https://api.mobilize.us/v1/endpoint/attendances` endpoint, takes data from the `event` that was attended, and loads some fields about that data into a bigquery table called 'events'.

## Changes I made

### Dumping data into Google Cloud Storage instead of local files
I've generally always dumped data from an API into a data lake (gcs, aws s3) before uploading it into the data warehouse (bigquery, redshift). The advantages are
1. The files never live on your device, which is useful if your laptop gets crushed or stolen or other team members want to see the data
2. You can inspect the data to see if something went wrong during a transformation process
3. You can backfill data into your warehouse from the data lake with relative ease in case anything ever happens to your database

I added a timestamp to the filename so that the data in GCS doesn't get overwritten each time this script gets run. If there's a lot of redundant data, this might fill storage quickly, but we can further refactor the script so we're pulling fresh data each time (see Future Work section)

### Transforming data before dumping into GCS instead of before loading into bigquery
I moved the event data extraction into its own function. This way, if we want to transform the data more extensively, we can see the results in GCS to doublecheck before it ends up in bigquery. Also, since data gets transformed a bit when it gets loaded into bq, this prevents the two transformations from happening back-to-back and simplifies future data debugging.

### Niceties
* I added docstrings to the top of the script and for each method
* I added a tiny amount of error handling / logging at each data load
* I used [smart_open](https://pypi.org/project/smart-open/) to stream data in and out of gcs

## Future work 
* I wanted to add pagination to grab all data, since this script will only grab the first 25.
* Also, I would love to add an `updated_after` filter to the request to only grab fresh data -- maybe the timestamp gets stored as an environmental variable wherever this script is being deployed? 
* I did a lot of `logging.error`, but not a lot of `logging.info`, which might be useful during debugging. 
* What happens when we do get errors by row? Should we skip them? Stop the whole presses and upload nothing? 
* We should probably be pinging the `events` endpoint to grab `events` data instead of pinging the `attendances` endpoint.
* Explore if there's a primary key in the events table. What does idempotency look like here? How do we avoid duplicates?
* This commit message could be more informative, but now I'm running out of time!

