### PR TITLE
Write json to csv script

### DIFF
--- a/process_data.py
+++ b/process_data.py
@@ -1,12 +1,127 @@
 import json
 import csv
 
+
+def build_event_row(event):
+    """
+    Takes event object from json and returns a dict of fields to upload.
+    """
+    if event:
+        return {
+            "id": event.get("id"),
+            "contact_id": event.get("contact"),
+            "sponsor_id": event.get("sponsor"),
+            "location": event.get("location"),
+            "title": event.get("title"),
+            "description": event.get("description"),
+            "featured_image_url": event.get("featured_image_url"),
+            "high_priority": event.get("high_priority"),
+            "timeslots": event.get("timeslots"),
+            "location": event.get("location"),
+            "timezone": event.get("timezone"),
+            "event_type": event.get("event_type"),
+            "browser_url": event.get("browser_url"),
+            "visibility": event.get("visibility"),
+            "address_visibility": event.get("address_visibility"),
+            "created_by_volunteer_host": event.get("created_by_volunteer_host"),
+            "is_virtual": event.get("is_virtual"),
+            "virtual_action_url": event.get("virtual_action_url"),
+            "accessibility_status": event.get("accessibility_status"),
+            "accessibility_notes": event.get("accessibility_notes"),
+            "tags": event.get("tags"),
+            "approval_status": event.get("approval_status"),
+            "event_campaign": event.get("event_campaign"),
+            "instructions": event.get("instructions"),
+            "created_date": event.get("created_date"),
+            "modified_date": event.get("modified_date"),
+        }
+
+
+def build_timeslot_row(timeslot):
+    """
+    Takes a timeslot object from json and returns a dict of fields to upload.
+
+    This function is really just here to ensure a specific order of fields.
+    """
+    if timeslot:
+        return {
+            "id": timeslot["id"],
+            "start_date": timeslot["start_date"],
+            "end_date": timeslot["end_date"],
+            "is_full": timeslot["is_full"],
+            "instructions": timeslot["instructions"],
+        }
+
+
+def build_people_row(person):
+    """
+    Takes a person object from json and returns a dict of fields to upload.
+
+    This function is really just here to ensure a specific order of fields.
+    """
+    if person:
+        return {
+            "id": person["user_id"],
+            "created_date": person["created_date"],
+            "modified_date": person["modified_date"],
+            "given_name": person["given_name"],
+            "family_name": person["family_name"],
+            "email_addresses": person["email_addresses"],
+            "phone_numbers": person["phone_numbers"],
+            "postal_addresses": person["postal_addresses"],
+            "sms_opt_in_status": person["sms_opt_in_status"],
+            "blocked_date": person["blocked_date"],
+        }
+
+
 attendances = {}
 # Open attendances JSON file
-with open('data/attendances.json') as f:
-  attendances = json.loads(f.read())
+with open("data/attendances.json") as f:
+    attendances = json.loads(f.read())
+
+# write events
+with open("output/events.csv", "w") as event_file:
+    writer = csv.writer(event_file)
+
+    # write the header
+    header = build_event_row(attendances[0]["event"]).keys()
+    writer.writerow(header)
+
+    for attendance in attendances:
+        event_row = build_event_row(attendance.get("event"))
+
+        # if there's an event in this attendance, write it
+        if event_row is not None:
+            writer.writerow(event_row.values())
+
+# write timeslots
+with open("output/timeslots.csv", "w") as timeslot_file:
+    writer = csv.writer(timeslot_file)
+
+    # write the header
+    header = build_timeslot_row(attendances[0]["timeslot"]).keys()
+    writer.writerow(header)
+
+    for attendance in attendances:
+        timeslot_row = build_timeslot_row(attendance.get("timeslot"))
+
+        # if there's a timeslot in this attendance, write it
+        if timeslot_row:
+            writer.writerow(timeslot_row.values())
+
+# write people
+with open("output/people.csv", "w") as people_file:
+    writer = csv.writer(people_file)
+
+    # write the header
+    header = build_people_row(attendances[0]["person"]).keys()
+    writer.writerow(header)
+
+    for attendance in attendances:
+        person_row = build_people_row(attendance.get("person"))
+
+        # if there's a people in this attendance, write it
+        if person_row:
+            writer.writerow(person_row.values())
 
 print("processed", len(attendances), "attendances")
-
-# add your code for processing this data here! 
-# see https://github.com/mobilizeamerica/api#attendances for data model documentation


### PR DESCRIPTION
This is a smallish script to parse the json data from the Mobilize `attendances` script into csvs.

Some choices I made:
* The `build_x_row()` methods are perhaps a little too manual, but I don't normally use pandas/`json_normalize` for data engineering purposes. If the data that the api returns ever changes, I prefer to not to parse through the decisions that `json_normalize` made for me while debugging. Having explicitly coded fields and values gives fewer surprises and more of a paper trail (via git pull requests) when data structures change.
* I iterated through the attendances json three times, once per csv, rather than writing all three csvs in one loop. It seemed cleaner this way to me.
* The code is rather redundant. I didn't have time to make it concise, but I would in real life.
* I chose to just dump nested dictionaries (sponsors, location, etc) into the csv rather than try to flatten them, and have downstream dbt-ers deal with the json, so that the bulk of the data transformation stays in dbt. I would rather the analytics engineers and the folks analyzing the data be opinionated about column names than myself.